### PR TITLE
Remove null fields from APIResponse type

### DIFF
--- a/pages/rest/connections.mdx
+++ b/pages/rest/connections.mdx
@@ -19,7 +19,7 @@ try to reconnect and auth.
 <Tabs items={['200']}>
 <Tabs.Tab>
 
-```typescript
+```typescript copy
 type InvalidateConnectionsResult = {};
 ```
 
@@ -37,14 +37,17 @@ try to reconnect and auth.
 
 ### Request
 
-<Resource method="POST" path="/connections/rooms/{uri-encoded-room-id}:invalidate" />
+<Resource
+  method="POST"
+  path="/connections/rooms/{uri-encoded-room-id}:invalidate"
+/>
 
 ### Response
 
 <Tabs items={['200', '4xx']}>
 <Tabs.Tab>
 
-```typescript
+```typescript copy
 type InvalidateConnectionsResult = {};
 ```
 
@@ -53,9 +56,9 @@ Full response type: [`SuccessResponse<InvalidateConnectionsResult>`](overview#20
 </Tabs.Tab>
 <Tabs.Tab>
 
-| Code | Resource | Description         |
-| :--- | :------- | :------------------ |
-| 404  | `rooms`  | Room not found      |
+| Code | Resource | Description    |
+| :--- | :------- | :------------- |
+| 404  | `rooms`  | Room not found |
 
 Full response type: [ErrorResponse](overview#4xx)
 
@@ -70,14 +73,17 @@ try to reconnect and auth.
 
 ### Request
 
-<Resource method="POST" path="/connections/users/{uri-encoded-user-id}:invalidate" />
+<Resource
+  method="POST"
+  path="/connections/users/{uri-encoded-user-id}:invalidate"
+/>
 
 ### Response
 
 <Tabs items={['200']}>
 <Tabs.Tab>
 
-```typescript
+```typescript copy
 type InvalidateConnectionsResult = {};
 ```
 

--- a/pages/rest/overview.mdx
+++ b/pages/rest/overview.mdx
@@ -7,7 +7,7 @@ integrate Reflect with your existing backend systems.
 
 ## Base URL
 
-```http
+```http copy
 https://api.reflect-server.net/
 ```
 
@@ -17,7 +17,7 @@ https://api.reflect-server.net/
 
 ### Generate an API key
 
-```bash
+```bash copy
 npx reflect keys create my-api-key
 ```
 
@@ -31,7 +31,7 @@ permissions and deleting (revoking) them.
 
 Pass the value of the key in the `Authorization` header of the request:
 
-```http
+```http copy
 Authorization: Basic {key-value}
 ```
 
@@ -54,10 +54,9 @@ Authorization: Basic {key-value}
 
 Success responses use the following JSON response body format:
 
-```typescript
+```typescript copy
 type SuccessResponse<T> = {
   result: T;
-  error: null;
 };
 ```
 
@@ -69,9 +68,8 @@ Consult the documentation for each endpoint for the result type `T`.
 
 The returned JSON response body provides details about the error:
 
-```typescript
+```typescript copy
 type ErrorResponse = {
-  result: null;
   error: {
     /** The HTTP status code */
     code: number;

--- a/pages/rest/rooms.mdx
+++ b/pages/rest/rooms.mdx
@@ -3,41 +3,6 @@ import { Permission, Resource } from "../../components/api";
 
 # Room Commands
 
-## Get room
-
-<Permission name="rooms:read" />
-
-### Request
-
-<Resource method="GET" path="/rooms/{uri-encoded-room-id}" />
-
-### Response
-
-<Tabs items={['200', '4xx']}>
-<Tabs.Tab>
-
-```typescript
-type GetRoomResult = {
-  roomID: string;
-  jurisdiction: "" | "eu";
-  status: "open" | "closed" | "deleted";
-};
-```
-
-Full response type: [`SuccessResponse<GetRoomResult>`](overview#200)
-
-</Tabs.Tab>
-<Tabs.Tab>
-
-| Code | Resource | Description    |
-| :--- | :------- | :------------- |
-| 404  | `rooms`  | Room not found |
-
-Full response type: [ErrorResponse](overview#4xx)
-
-</Tabs.Tab>
-</Tabs>
-
 ## List rooms
 
 <Permission name="rooms:read" />
@@ -61,7 +26,7 @@ Full response type: [ErrorResponse](overview#4xx)
 
 Rooms are returned in lexicographical `roomID` order.
 
-```typescript
+```typescript copy
 type GetRoomResult = {
   roomID: string;
   jurisdiction: "" | "eu";
@@ -97,6 +62,41 @@ Full response type: [ErrorResponse](overview#4xx)
 </Tabs.Tab>
 </Tabs>
 
+## Get room
+
+<Permission name="rooms:read" />
+
+### Request
+
+<Resource method="GET" path="/rooms/{uri-encoded-room-id}" />
+
+### Response
+
+<Tabs items={['200', '4xx']}>
+<Tabs.Tab>
+
+```typescript copy
+type GetRoomResult = {
+  roomID: string;
+  jurisdiction: "" | "eu";
+  status: "open" | "closed" | "deleted";
+};
+```
+
+Full response type: [`SuccessResponse<GetRoomResult>`](overview#200)
+
+</Tabs.Tab>
+<Tabs.Tab>
+
+| Code | Resource | Description    |
+| :--- | :------- | :------------- |
+| 404  | `rooms`  | Room not found |
+
+Full response type: [ErrorResponse](overview#4xx)
+
+</Tabs.Tab>
+</Tabs>
+
 ## Create room
 
 A room is automatically created if it does not exist when a Reflect client connects to it.
@@ -112,7 +112,7 @@ This call can be used to explicitly create a room.
 
 (required)
 
-```typescript
+```typescript copy
 type CreateRoomRequest = {
   jurisdiction?: "eu";
 };
@@ -123,7 +123,7 @@ type CreateRoomRequest = {
 <Tabs items={['200', '4xx']}>
 <Tabs.Tab>
 
-```typescript
+```typescript copy
 type CreateRoomResult = {};
 ```
 
@@ -163,7 +163,7 @@ Closing a room does not delete its data. Use the
 <Tabs items={['200', '4xx']}>
 <Tabs.Tab>
 
-```typescript
+```typescript copy
 type CloseRoomResult = {};
 ```
 
@@ -200,7 +200,7 @@ have had its users logged out via [invalidate room connections](connections#inva
 <Tabs items={['200', '4xx']}>
 <Tabs.Tab>
 
-```typescript
+```typescript copy
 type DeleteRoomResult = {};
 ```
 


### PR DESCRIPTION
Removes null fields from `APIResponse` union type.

Also:
* Reordered rooms commands so that `list` comes first.
* Added `copy` to most code blocks